### PR TITLE
Allow moving the window outside the screen & to another screen with hotkeys

### DIFF
--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
@@ -93,6 +93,7 @@ FlatWndProc::FlatWndProc() {
 	containInScreen = false;
 	isMovingOrSizing = false;
 	isMoving = false;
+	allowMovingOutsideMonitor = false;
 }
 
 HWND FlatWndProc::install( JNIEnv *env, jobject obj, jobject window ) {
@@ -285,6 +286,10 @@ LRESULT CALLBACK FlatWndProc::WindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 			isMovingOrSizing = isMoving = false;
 			break;
 
+		case WM_CAPTURECHANGED:
+			allowMovingOutsideMonitor = isMovingOrSizing;
+			break;
+
 		case WM_SIZING:
 			return WmSizingOrMoving( hwnd, uMsg, wParam, lParam );
 		case WM_MOVE:
@@ -293,6 +298,16 @@ LRESULT CALLBACK FlatWndProc::WindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 				isMoving = true;
 			if (uMsg == WM_MOVING)
 				return WmSizingOrMoving( hwnd, uMsg, wParam, lParam );
+			break;
+
+		case WM_WINDOWPOSCHANGING:
+			if (allowMovingOutsideMonitor) {
+			    // Prevent the top of the window from being forcefully contained in the
+			    // screen when the window is being moved by the mouse
+				WINDOWPOS* winpos = reinterpret_cast<WINDOWPOS*>(lParam);
+				winpos->flags |= SWP_NOMOVE;
+				allowMovingOutsideMonitor = false;
+			}
 			break;
 
 		case WM_ERASEBKGND:

--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
@@ -285,10 +285,14 @@ LRESULT CALLBACK FlatWndProc::WindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 			isMovingOrSizing = isMoving = false;
 			break;
 
+		case WM_SIZING:
+			return WmSizingOrMoving( hwnd, uMsg, wParam, lParam );
 		case WM_MOVE:
 		case WM_MOVING:
 			if( isMovingOrSizing )
 				isMoving = true;
+			if (uMsg == WM_MOVING)
+				return WmSizingOrMoving( hwnd, uMsg, wParam, lParam );
 			break;
 
 		case WM_ERASEBKGND:
@@ -304,9 +308,6 @@ LRESULT CALLBACK FlatWndProc::WindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 
 		case WM_DESTROY:
 			return WmDestroy( hwnd, uMsg, wParam, lParam );
-
-		case WM_WINDOWPOSCHANGING:
-			return WmWindowPosChanging( hwnd, uMsg, wParam, lParam );
 	}
 
 	return ::CallWindowProc( defaultWndProc, hwnd, uMsg, wParam, lParam );
@@ -441,8 +442,7 @@ LRESULT FlatWndProc::WmNcHitTest( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lPa
 	return onNcHitTest( x, y, isOnResizeBorder );
 }
 
-LRESULT FlatWndProc::WmWindowPosChanging(HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam)
-{
+LRESULT FlatWndProc::WmSizingOrMoving(HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam) {
 	if (!containInScreen)
 		return CallWindowProc(defaultWndProc, hwnd, uMsg, wParam, lParam);
 
@@ -467,25 +467,39 @@ LRESULT FlatWndProc::WmWindowPosChanging(HWND hwnd, int uMsg, WPARAM wParam, LPA
 		insets.right = outside.right - inside.right;
 	}
 
-	WINDOWPOS *winpos = reinterpret_cast<WINDOWPOS *>(lParam);
+	RECT *winrect = reinterpret_cast<RECT *>(lParam);
 	const RECT &rcMonitor = info.rcMonitor;
 
-	if (winpos->x + winpos->cx - insets.right > rcMonitor.right)
+	LONG width = winrect->right - winrect->left;
+	LONG height = winrect->bottom - winrect->top;
+
+    // Adjust both sides only for move operations
+	BOOL isMoving = uMsg == WM_MOVING;
+
+	if (winrect->right - insets.right > rcMonitor.right)
 	{
-		winpos->x = rcMonitor.right - winpos->cx + insets.right;
+		winrect->right = rcMonitor.right + insets.right;
+		if (isMoving)
+			winrect->left = winrect->right - width;
 	}
-	else if (winpos->x + insets.left < rcMonitor.left)
+	else if (winrect->left + insets.left < rcMonitor.left)
 	{
-		winpos->x = rcMonitor.left - insets.left;
+		winrect->left = rcMonitor.left - insets.left;
+		if (isMoving)
+			winrect->right = winrect->left + width;
 	}
 
-	if (winpos->y + insets.top < rcMonitor.top)
+	if (winrect->top + insets.top < rcMonitor.top)
 	{
-		winpos->y = rcMonitor.top - insets.top;
+		winrect->top = rcMonitor.top - insets.top;
+		if (isMoving)
+			winrect->bottom = winrect->top + height;
 	}
-	else if (winpos->y + winpos->cy - insets.bottom > rcMonitor.bottom)
+	else if (winrect->bottom - insets.bottom > rcMonitor.bottom)
 	{
-		winpos->y = rcMonitor.bottom - winpos->cy + insets.bottom;
+		winrect->bottom = rcMonitor.bottom + insets.bottom;
+		if (isMoving)
+			winrect->top = winrect->bottom - height;
 	}
 
 	return CallWindowProc(defaultWndProc, hwnd, uMsg, wParam, lParam);

--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
@@ -47,6 +47,7 @@ private:
 	bool containInScreen;
 	bool isMovingOrSizing;
 	bool isMoving;
+	bool allowMovingOutsideMonitor;
 
 	FlatWndProc();
 	static void initIDs( JNIEnv *env, jobject obj );

--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
@@ -57,7 +57,7 @@ private:
 	LRESULT WmEraseBkgnd( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam );
 	LRESULT WmNcCalcSize( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam );
 	LRESULT WmNcHitTest( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam );
-	LRESULT WmWindowPosChanging( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam );
+	LRESULT WmSizingOrMoving( HWND hwnd, int uMsg, WPARAM wParam, LPARAM lParam );
 
 	LRESULT screen2windowCoordinates( HWND hwnd, LPARAM lParam );
 	int getResizeHandleHeight();


### PR DESCRIPTION
Fixes a few bugs:
- Allow moving the window to other monitors using Windows key + shift + left/right and Windows key + left/right x2.
- Fix bug with [toggling the sidebar while the window is next to the right edge of the screen](https://discord.com/channels/301497432909414422/442492468307427330/1200579261875105882).
- Allow dragging the window off the top end of the screen.